### PR TITLE
Fix: Reimplemented base32tohex for better error handling

### DIFF
--- a/utils/auth.js
+++ b/utils/auth.js
@@ -40,7 +40,6 @@ export default function(account, secret, issuer) {
     }
 
     this.getOtp = function() {
-        const logger = DeviceRuntimeCore.HmLogger.getLogger('helloworld');
 
         var key = base32tohex(secret);
         var epoch = Math.round(new Date().getTime() / 1000.0);


### PR DESCRIPTION
This pull request fixed #13 by rewriting `base32tohex` function.